### PR TITLE
Release v0.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openapi-to-effect",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openapi-to-effect",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MPL-2.0",
       "dependencies": {
         "effect": "^3.10.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-to-effect",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "MPL-2.0",
   "homepage": "https://github.com/fortanix/openapi-to-effect",
   "description": "OpenAPI to Effect Schema code generator",


### PR DESCRIPTION
Changes:

- Moved from `@effect/schema` to stable `effect` v3.10 which now includes Schema out of the box.